### PR TITLE
_toolchain and _scripts are not included in the pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include relenv/_scripts *
+recursive-include relenv/_toolchain *

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup()
+    setup(include_package_data=True)


### PR DESCRIPTION
Currently, _toolchain and _scripts are not included in the pip package. This leads to build errors when running `relenv toolchain build`.

This resolves saltstack/relenv#199