### PR TITLE
Using GHA public linux runner tags

### DIFF
--- a/.github/workflows/build-cross-action.yml
+++ b/.github/workflows/build-cross-action.yml
@@ -37,7 +37,7 @@ jobs:
       ( matrix.host  !=  matrix.target  &&  inputs.kind  == "cross" )
 
     runs-on:
-      - ${{ (contains(matrix.host, "x86_64") && "linux-x86_64") || "linux-arm64" }}
+      - ${{ (contains(matrix.host, "x86_64") && "ubuntu-24.04") || "ubuntu-24.04-arm" }}
 
     env:
       RELENV_DATA: ${{ github.workspace }}

--- a/.github/workflows/build-native-action.yml
+++ b/.github/workflows/build-native-action.yml
@@ -32,7 +32,7 @@ jobs:
     name: "Python ${{ matrix.version }}  Linux ${{ matrix.target }} on ${{ matrix.host }}"
 
     runs-on:
-      - ${{ (contains(matrix.host, 'x86_64') && 'linux-x86_64') || 'linux-arm64' }}
+      - ${{ (contains(matrix.host, 'x86_64') && 'ubuntu-24.04') || 'ubuntu-24.04-arm' }}
 
     env:
       RELENV_DATA: ${{ github.workspace }}

--- a/.github/workflows/toolchain-action.yml
+++ b/.github/workflows/toolchain-action.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Toolchain ${{ matrix.target }} on ${{ matrix.host }}"
 
     runs-on:
-      - ${{ (contains(matrix.host, 'x86_64') && 'linux-x86_64') || 'linux-arm64' }}
+      - ${{ (contains(matrix.host, 'x86_64') && 'ubuntu-24.04') || 'ubuntu-24.04-arm' }}
 
     #if: fromJSON(inputs.changed-files)['toolchain'] == 'true'
 


### PR DESCRIPTION
Moving away from `linux-*` runner tags to generic GHA free `ubuntu-*` `runs-on:` tags