### PR TITLE
Extract toolchain to relenv data directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.20.2
+======
+
+* Extract ppbt toolchain to relenv data directory so it can be re-used accross
+  environments.
+
+
 0.20.1
 ======
 

--- a/relenv/common.py
+++ b/relenv/common.py
@@ -18,7 +18,7 @@ import threading
 import time
 
 # relenv package version
-__version__ = "0.20.1"
+__version__ = "0.20.2"
 
 MODULE_DIR = pathlib.Path(__file__).resolve().parent
 
@@ -232,13 +232,19 @@ def get_toolchain(arch=None, root=None):
     ppbt = None
 
     try:
-        import ppbt
+        import ppbt.common
     except ImportError:
         pass
 
     if ppbt:
-        env = ppbt.environ(auto_extract=True)
-        return pathlib.Path(env["TOOLCHAIN_PATH"])
+        DATA_DIR.mkdir(exist_ok=True)
+        TOOLCHAIN_ROOT = DATA_DIR / "toolchain"
+        TOOLCHAIN_ROOT.mkdir(exist_ok=True)
+        TOOLCHAIN_PATH = TOOLCHAIN_ROOT / get_triplet()
+        if TOOLCHAIN_PATH.exists():
+            return TOOLCHAIN_PATH
+        ppbt.common.extract_archive(str(TOOLCHAIN_ROOT), str(ppbt.common.ARCHIVE))
+        return TOOLCHAIN_PATH
 
 
 def get_triplet(machine=None, plat=None):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -29,8 +29,7 @@ def test_builder_defaults_linux():
     assert builder.prefix == DATA_DIR / "build" / "3.10.10-x86_64-linux-gnu"
     assert builder.sources == DATA_DIR / "src"
     assert builder.downloads == DATA_DIR / "download"
-    assert "ppbt" in str(builder.toolchain)
-    assert "_toolchain" in str(builder.toolchain)
+    assert "relenv/toolchain" in str(builder.toolchain)
     assert callable(builder.build_default)
     assert callable(builder.populate_env)
     assert builder.recipies == {}

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -127,7 +127,7 @@ def test_get_toolchain(tmp_path):
         if sys.platform in ["darwin", "win32"]:
             assert "data" in str(ret)
         else:
-            assert "ppbt" in str(ret)
+            assert f"{data_dir}/toolchain" in str(ret)
 
 
 def test_get_toolchain_no_arch(tmp_path):
@@ -137,7 +137,7 @@ def test_get_toolchain_no_arch(tmp_path):
         if sys.platform in ["darwin", "win32"]:
             assert "data" in str(ret)
         else:
-            assert "ppbt" in str(ret)
+            assert f"{data_dir}/toolchain" in str(ret)
 
 
 @pytest.mark.parametrize("open_arg", (":gz", ":xz", ":bz2", ""))


### PR DESCRIPTION
This makes things work more like they did prior to `ppbt`. We extract the `ppbt` toolchain to the relenv data directory so it can be re-used across various python environments without having to install `ppbt` everytime a toolchain is required.