### PR TITLE
Revert cargo home location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
+0.20.6
+======
+
+* Revert relenv's cargo home from temp directory back to relenv's data
+  directory.
+
+
 0.20.5
 ======
 
 * Update gdbm from 1.25 to 1.26
 * Update libffi from 3.5.1 to 3.5.2
 * Update readline from 8.2.13 to 8.3
-* Update sqlite from 3.50.2 to 3.50.4 
+* Update sqlite from 3.50.2 to 3.50.4
 
 
 0.20.4

--- a/relenv/common.py
+++ b/relenv/common.py
@@ -18,7 +18,7 @@ import threading
 import time
 
 # relenv package version
-__version__ = "0.20.5"
+__version__ = "0.20.6"
 
 MODULE_DIR = pathlib.Path(__file__).resolve().parent
 

--- a/relenv/runtime.py
+++ b/relenv/runtime.py
@@ -613,7 +613,7 @@ def wrap_pip_build_wheel(name):
                 return func(*args, **kwargs)
             base_dir = common().DATA_DIR / "toolchain"
             toolchain = base_dir / common().get_triplet()
-            cargo_home = install_cargo_config.tmpdir.name
+            cargo_home = str(common().DATA_DIR / "cargo")
             if not toolchain.exists():
                 debug("Unable to set CARGO_HOME no toolchain exists")
             else:
@@ -844,13 +844,9 @@ def install_cargo_config():
     # We need this as a late import for python < 3.12 becuase importing it will
     # load the ssl module. Causing out setup_openssl method to fail to load
     # fips module.
-    import tempfile
-
-    install_cargo_config.tmpdir = tempfile.TemporaryDirectory(prefix="relenvcargo")
-    cargo_home = pathlib.Path(install_cargo_config.tmpdir.name)
-
+    dirs = common().work_dirs()
     triplet = common().get_triplet()
-    # dirs = common().work_dirs()
+    cargo_home = dirs.data / "cargo"
 
     toolchain = common().get_toolchain()
     if not toolchain:


### PR DESCRIPTION
Using a temporary directory for cargo has some drawbacks. It fails to get cleaned up if the process changes it's user id. Rather than leave the temporary directories around let's go back to using relenv's data directory for cargo home.

saltstack/salt#68294