### PR TITLE
Update Python and dependency versions in python-versions.json

### DIFF
--- a/relenv/python-versions.json
+++ b/relenv/python-versions.json
@@ -188,7 +188,8 @@
   "3.13.12": "7c5b0241cb7d33d4eab78c9fd44967b08220dfe7",
   "3.12.13": "ad3e9c333d91bee73f1d5f4a6fe6e88f2e74d911",
   "3.11.15": "e434ba0457a632f86e73239174bb1737cb57c09c",
-  "3.10.20": "33b99a3309d5a0323b71a4764543f61ff1fcf8f3"
+  "3.10.20": "33b99a3309d5a0323b71a4764543f61ff1fcf8f3",
+  "3.13.13": "be80bbd34ab6627c464a2a2d965d8b8fa5aa2388"
  },
  "dependencies": {
   "perl": {
@@ -205,12 +206,28 @@
     "platforms": [
      "win32"
     ]
+   },
+   "5.42.2.1": {
+    "url": "https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_54221_64bit/strawberry-perl-{version}-64bit-portable.zip",
+    "sha256": "32d83be90cf04b807cfb9477482bc36302cdee6f5b04cf57e81adecbd8f07898",
+    "platforms": [
+     "win32"
+    ]
    }
   },
   "openssl": {
    "3.5.5": {
     "url": "https://github.com/openssl/openssl/releases/download/openssl-{version}/openssl-{version}.tar.gz",
     "sha256": "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89",
+    "platforms": [
+     "linux",
+     "darwin",
+     "win32"
+    ]
+   },
+   "3.5.6": {
+    "url": "https://github.com/openssl/openssl/releases/download/openssl-{version}/openssl-{version}.tar.gz",
+    "sha256": "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
     "platforms": [
      "linux",
      "darwin",
@@ -253,6 +270,16 @@
     "url": "https://sqlite.org/2026/sqlite-autoconf-{version}.tar.gz",
     "sha256": "81f5be397049b0cae1b167f2225af7646fc0f82e4a9b3c48c9ea3a533e21d77a",
     "sqliteversion": "3510300",
+    "platforms": [
+     "linux",
+     "darwin",
+     "win32"
+    ]
+   },
+   "3.53.0.0": {
+    "url": "https://sqlite.org/2026/sqlite-autoconf-{version}.tar.gz",
+    "sha256": "851e9b38192fe2ceaa65e0baa665e7fa06230c3d9bd1a6a9662d02380d73365a",
+    "sqliteversion": "3530000",
     "platforms": [
      "linux",
      "darwin",


### PR DESCRIPTION
Updated Python to 3.13.13 and critical dependencies to address several vulnerabilities:

Python 3.13.13
- CVE-2026-3479: Improper resource argument validation in pkgutil.get_data()
- CVE-2026-2297: Incorrectly handled hook in FileLoader
- CVE-2025-13462: Incorrect parsing of TarInfo with GNU long name
- CVE-2025-27607: RCE in python-json-logger dependency

Perl 5.42.2.1
- CVE-2026-4176: Memory corruption in Compress::Raw::Zlib core module
- CVE-2026-3381 / CVE-2026-27171: zlib vulnerabilities within compression capabilities

OpenSSL 3.5.6
- CVE-2026-31790: Leakage from uninitialized memory in RSA KEM RSASVE
- CVE-2026-2673: Loss of key agreement group tuple structure
- CVE-2026-28387: Potential use-after-free in DANE client code
- CVE-2026-28388: DoS via NULL pointer dereference in delta CRL processing
- CVE-2026-31789: Heap buffer overflow in hexadecimal conversion
- CVE-2026-28389 / CVE-2026-28390: NULL pointer dereferences in CMS processing

SQLite 3.53.0.0
- CVE-2025-6965: High-severity memory corruption flaw in aggregate terms