### PR TITLE
Limit auto-update PR to the files we actually changed

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -74,3 +74,7 @@ jobs:
           base: "main"
           delete-branch: true
           labels: "automated-update"
+          add-paths: |
+            relenv/python-versions.json
+            relenv/common.py
+            CHANGELOG.md


### PR DESCRIPTION
`peter-evans/create-pull-request` defaults to `git add -A` which sweeps up the Python source tarballs and signatures that `relenv versions` leaves in the working tree (e.g. PR #296 included Python-3.13.14.tar.xz and a .asc).  Constrain the action to the three files we mean to commit.