### PR TITLE
Drive wheel build mode from `kind` instead of an arbitrary `cmd` input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,6 @@ on:
         required: false
         type: string
         default: dev
-      package_command:
-        required: false
-        type: string
-        description: Command used to build python package
-        default: >-
-          python -m
-          build
-          -C--global-option=egg_info
-          -C--global-option=--tag-build=+dev$(git rev-parse --short HEAD)
-          --wheel
-          --outdir dist/
     secrets:
       PRIVATE_KEY:
         required: false
@@ -72,7 +61,6 @@ jobs:
       - pre-commit
     with:
       kind: "${{ inputs.kind }}"
-      cmd: "${{ inputs.package_command }}"
 
   build-native:
     name: Python Native Builds

--- a/.github/workflows/package-action.yml
+++ b/.github/workflows/package-action.yml
@@ -7,17 +7,7 @@ on:
         required: false
         type: string
         default: dev
-      cmd:
-        required: false
-        type: string
-        description: Command used to build python package
-        default: >-
-          python -m
-          build
-          -C--global-option=egg_info
-          -C--global-option=--tag-build=dev$(git rev-parse --short HEAD)
-          --wheel
-          --outdir dist/
+        description: "'release' produces a clean PEP 440 version; anything else tags the build with +dev<sha>."
     outputs:
       version:
         value: "${{ jobs.build.outputs.version }}"
@@ -67,11 +57,18 @@ jobs:
         pkginfo
         --user
 
-    - name: Echo Build Wheel Command
-      run: echo "${{ inputs.cmd }}"
+    - name: Build Release Wheel
+      if: inputs.kind == 'release'
+      run: python -m build --wheel --outdir dist/
 
-    - name: Build Wheel
-      run: "${{ inputs.cmd }}"
+    - name: Build Dev Wheel
+      if: inputs.kind != 'release'
+      run: >-
+        python -m build
+        -C--global-option=egg_info
+        -C--global-option=--tag-build=+dev$(git rev-parse --short HEAD)
+        --wheel
+        --outdir dist/
 
     - name: Python Build Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,6 @@ on:
         required: false
         type: string
         default: dev
-      package_command:
-        required: false
-        type: string
-        description: Command used to build python package
-        default: >-
-          python -m
-          build
-          --wheel
-          --outdir dist/
 
 jobs:
   ci:
@@ -28,6 +19,5 @@ jobs:
     if: contains('["dwoz", "twangboy", "dmurhpy18"]', github.actor)
     with:
       kind: "${{ inputs.kind }}"
-      package_command: "${{ inputs.package_command }}"
     secrets:
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
package-action.yml accepted a `kind` input but never used it.  Its `cmd` input — what actually decided the wheel build — defaulted to a command that appends a PEP 440 local version (`+dev<sha>`) on every build, including release builds called from auto-release.yml.

PyPI rejects local versions, so the latest deploy run blew up with "400 The use of local versions in '0.22.13+devd3eddac' is not allowed."

Make `kind` the source of truth:

  kind == release  -> python -m build --wheel --outdir dist/
  otherwise        -> ... --tag-build=+dev<sha> ... (existing dev path)

Drop the now-redundant `package_command`/`cmd` plumbing from ci.yml, release.yml, and package-action.yml.  auto-release.yml already passes kind=release, so the same change fixes the merge-triggered path too.