### PR TITLE
Share Linux build deps via artifact, not cache

### DIFF
--- a/.github/workflows/build-native-action.yml
+++ b/.github/workflows/build-native-action.yml
@@ -27,11 +27,21 @@ jobs:
       - name: Download Dependencies
         run: |
           python3 -m relenv build --download-only
-      - name: Cache Dependencies
-        uses: actions/cache@v4
+      # Use an artifact instead of actions/cache: cache writes are scoped
+      # to the workflow's head ref, and Auto-Release fires on
+      # `pull_request: closed` where the source branch has just been
+      # deleted by auto-merge.yml's `--delete-branch`.  With no valid ref
+      # for the cache scope, the runtime token has no writable scopes
+      # and the save fails ("token has no writable scopes").  Artifacts
+      # are scoped to the run_id, not a branch ref, so branch deletion
+      # doesn't affect them.
+      - name: Upload Build Dependencies Artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: python-build-download
           path: ${{ github.workspace }}/download
-          key: ${{ github.run_id }}-dependencies
+          retention-days: 1
+          if-no-files-found: error
 
   build_linux:
     strategy:
@@ -86,11 +96,11 @@ jobs:
           venv/bin/python3 --version
           venv/bin/python3 -c 'import os; print(os.name)'
 
-      - name: Restore Cached Dependencies
-        uses: actions/cache/restore@v4
+      - name: Download Build Dependencies Artifact
+        uses: actions/download-artifact@v4
         with:
+          name: python-build-download
           path: ${{ github.workspace }}/download
-          key: ${{ github.run_id }}-dependencies
 
       - name: List downloads
         run: |


### PR DESCRIPTION
The Auto-Release workflow fires on pull_request: closed and its head ref is the (now-deleted) PR source branch — auto-merge.yml uses `gh pr merge --delete-branch`.  GitHub Actions scopes cache writes to the workflow's head ref; with the ref already deleted by the time Auto-Release starts, the runtime token has no writable scopes and the save fails with:

    Cache reservation failed: cache write denied: token has no writable scopes
    Failed to save: Unable to reserve cache with key <run_id>-dependencies

The downstream build_linux jobs then hit "Cache not found" during restore, tree $RELENV_DATA/download errors out, and every Linux entry fails.  That's what killed the 0.22.17 release run (28422611083).  The same run on pr.yml's push-to-main path (28422611021) worked because main is a real ref with a valid cache scope.

Artifacts are scoped to the run_id, not a branch ref, so branch deletion doesn't affect them.  Swap the actions/cache pair for actions/upload-artifact + actions/download-artifact:

  - retention-days: 1 keeps the artifact tiny in storage
  - if-no-files-found: error catches the case where --download-only silently produced nothing

Behaviour is identical for the pr.yml path (both cache and artifact work there); the Auto-Release path stops failing.